### PR TITLE
chore: upgrade mermaid from 10.2.3 to 11.15.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
 
     <!-- Import the required libraries -->
     <script src="https://cdn.jsdelivr.net/npm/marked@4.3.0/marked.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/mermaid@10.2.3/dist/mermaid.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.js" integrity="sha384-cpW21h6RZv/phavutF+AuVYrr+dA8xD9zs6FwLpaCct6O9ctzYFfFr4dgmgccOTx" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/contrib/auto-render.min.js" integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05" crossorigin="anonymous"></script>

--- a/js/export.js
+++ b/js/export.js
@@ -717,7 +717,7 @@ class AdvancedExportSystem {
                     <meta charset="UTF-8">
                     <title>PDF Export</title>
                     <style>${css}</style>
-                    <script src="https://cdn.jsdelivr.net/npm/mermaid@10.2.3/dist/mermaid.min.js"></script>
+                    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.min.js"></script>
                 </head>
                 <body>
                     <div class="export-content">${content}</div>


### PR DESCRIPTION
Update CDN reference in index.html and js/export.js from mermaid@10.2.3 to mermaid@11.15.0 (latest stable).

Changelog: https://github.com/mermaid-js/mermaid/releases